### PR TITLE
add vt6::common::core::DecodeArgument trait

### DIFF
--- a/src/common/core/decode_argument.rs
+++ b/src/common/core/decode_argument.rs
@@ -1,0 +1,133 @@
+/*******************************************************************************
+*
+* Copyright 2018 Stefan Majewsky <majewsky@gmx.net>
+*
+* This program is free software: you can redistribute it and/or modify it under
+* the terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program. If not, see <http://www.gnu.org/licenses/>.
+*
+*******************************************************************************/
+
+use std;
+
+///A trait for types that can be decoded from an argument in a [VT6 message](msg/).
+///
+///This is the inverse of [`trait EncodeArgument`](trait.EncodeArgument.html).
+///
+///A notable difference is that this trait is *not* implemented for strings and
+///bytestrings because neither `[u8]` nor `str` are `Sized`. To decode an
+///argument into a `&str`, use `std::str::from_utf8()`. If `&[u8]` is the
+///desired value type, no decoding is required.
+///
+///The trait implementations for booleans and integers match the formats defined
+///for basic property types in
+///[vt6/core1.0, section 2.4](https://vt6.io/std/core/1.0/#section-2-4).
+pub trait DecodeArgument: Sized {
+    ///Parses a bytestring `s` (which is interpreted as an argument in a VT6
+    ///message) into a value of this type. If parsing succeeds, `Some` is
+    ///returned, otherwise `None` is returned.
+    fn decode(arg: &[u8]) -> Option<Self>;
+}
+
+impl DecodeArgument for bool {
+    fn decode(arg: &[u8]) -> Option<Self> {
+        match arg {
+            b"t" => Some(true),
+            b"f" => Some(false),
+            _    => None,
+        }
+    }
+}
+
+macro_rules! impl_DecodeArgument_for_integer {
+    ($($t:ident),*) => ($(
+
+        impl DecodeArgument for $t {
+            fn decode(arg: &[u8]) -> Option<Self> {
+                //forbid leading zeroes
+                if arg.len() == 0 {
+                    return None;
+                }
+                if arg != b"0" && arg[0] == b'0' {
+                    return None;
+                }
+
+                std::str::from_utf8(arg).ok()?.parse().ok()
+            }
+        }
+
+    )*);
+}
+
+impl_DecodeArgument_for_integer!(
+    i8, u8, i16, u16, i32, u32, i64, u64, i128, u128, isize, usize);
+
+#[cfg(test)]
+mod tests {
+
+    use common::core::*;
+
+    #[test]
+    fn test_decode_bool() {
+        assert_eq!(bool::decode(b"t"),       Some(true));
+        assert_eq!(bool::decode(b"f"),       Some(false));
+        assert_eq!(bool::decode(b"unknown"), None);
+        assert_eq!(bool::decode(b"1"),       None);
+        assert_eq!(bool::decode(b"0"),       None);
+        assert_eq!(bool::decode(b"true"),    None);
+        assert_eq!(bool::decode(b"false"),   None);
+    }
+
+    //NOTE: The tests below only test error cases (where `decode(...)` returns
+    //None), since the positive cases are covered in encode_argument.rs, where
+    //it is checked if `decode(encode(x)) == x`.
+
+    #[test]
+    fn test_decode_u8_fails() {
+        let invalid_inputs: Vec<&'static [u8]> = vec![
+            b"",
+            b"unknown",
+            b"\xC0\xB1", //UTF-8 overlong encoding of "1"
+            b" 42",      //whitespace in front
+            b"042",      //zeroes in front
+            b"0042",     //more zeroes in front
+        ];
+
+        for input in invalid_inputs {
+            assert_eq!(None, i8::decode(input));
+            assert_eq!(None, u8::decode(input));
+            assert_eq!(None, i16::decode(input));
+            assert_eq!(None, u16::decode(input));
+            assert_eq!(None, i32::decode(input));
+            assert_eq!(None, u32::decode(input));
+            assert_eq!(None, i64::decode(input));
+            assert_eq!(None, u64::decode(input));
+            assert_eq!(None, i128::decode(input));
+            assert_eq!(None, u128::decode(input));
+            assert_eq!(None, isize::decode(input));
+            assert_eq!(None, usize::decode(input));
+        }
+    }
+
+    #[test]
+    fn test_decode_moduleversion_fails() {
+        assert_eq!(None, ModuleVersion::decode(b""));
+        assert_eq!(None, ModuleVersion::decode(b"1"));
+        assert_eq!(None, ModuleVersion::decode(b"1."));
+        assert_eq!(None, ModuleVersion::decode(b".1"));
+        assert_eq!(None, ModuleVersion::decode(b"1.2.3"));
+        assert_eq!(None, ModuleVersion::decode(b".1.2"));
+        assert_eq!(None, ModuleVersion::decode(b"1.2."));
+        assert_eq!(None, ModuleVersion::decode(b"1..2"));
+        assert_eq!(None, ModuleVersion::decode(b"1.abc"));
+    }
+
+}

--- a/src/common/core/decode_argument.rs
+++ b/src/common/core/decode_argument.rs
@@ -1,20 +1,20 @@
-/*******************************************************************************
+/******************************************************************************
 *
-* Copyright 2018 Stefan Majewsky <majewsky@gmx.net>
+*  Copyright 2018 Stefan Majewsky <majewsky@gmx.net>
 *
-* This program is free software: you can redistribute it and/or modify it under
-* the terms of the GNU General Public License as published by the Free Software
-* Foundation, either version 3 of the License, or (at your option) any later
-* version.
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
 *
-* This program is distributed in the hope that it will be useful, but WITHOUT ANY
-* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-* A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*      http://www.apache.org/licenses/LICENSE-2.0
 *
-* You should have received a copy of the GNU General Public License along with
-* this program. If not, see <http://www.gnu.org/licenses/>.
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
 *
-*******************************************************************************/
+******************************************************************************/
 
 use std;
 

--- a/src/common/core/encode_argument.rs
+++ b/src/common/core/encode_argument.rs
@@ -18,8 +18,10 @@
 
 ///A trait for types that can be encoded as an argument in a [VT6 message](msg/).
 ///
-///The trait implementations for strings, byte strings and integers match the
-///formats defined for basic property types in
+///This is the inverse of [`trait DecodeArgument`](trait.DecodeArgument.html).
+///
+///The trait implementations for strings, byte strings, booleans and integers
+///match the formats defined for basic property types in
 ///[vt6/core1.0, section 2.4](https://vt6.io/std/core/1.0/#section-2-4).
 pub trait EncodeArgument {
     ///Returns the exact number of bytes that is required to encode this
@@ -118,7 +120,17 @@ mod tests {
 
     use common::core::*;
     use std::str;
-    use std::fmt::Display;
+    use std::fmt::{Debug, Display};
+
+    fn check_encodes_like_display_and_decodes<T: EncodeArgument + DecodeArgument + Display + Debug + Eq>(val: &T) {
+        check_encodes_like_display(val);
+
+        let size = val.get_size();
+        let mut buf = vec![0u8; size];
+        val.encode(&mut buf);
+
+        assert_eq!(Some(val), T::decode(&buf).as_ref());
+    }
 
     fn check_encodes_like_display<T: EncodeArgument + Display + ?Sized>(val: &T) {
         let size = val.get_size();
@@ -153,100 +165,100 @@ mod tests {
 
     #[test]
     fn test_encode_unsigned() {
-        check_encodes_like_display(&0u8);
-        check_encodes_like_display(&42u8);
-        check_encodes_like_display(&(u8::max_value() - 1));
-        check_encodes_like_display(&(u8::max_value()));
+        check_encodes_like_display_and_decodes(&0u8);
+        check_encodes_like_display_and_decodes(&42u8);
+        check_encodes_like_display_and_decodes(&(u8::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(u8::max_value()));
 
-        check_encodes_like_display(&0u16);
-        check_encodes_like_display(&42u16);
-        check_encodes_like_display(&(u16::max_value() - 1));
-        check_encodes_like_display(&(u16::max_value()));
+        check_encodes_like_display_and_decodes(&0u16);
+        check_encodes_like_display_and_decodes(&42u16);
+        check_encodes_like_display_and_decodes(&(u16::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(u16::max_value()));
 
-        check_encodes_like_display(&0u32);
-        check_encodes_like_display(&42u32);
-        check_encodes_like_display(&(u32::max_value() - 1));
-        check_encodes_like_display(&(u32::max_value()));
+        check_encodes_like_display_and_decodes(&0u32);
+        check_encodes_like_display_and_decodes(&42u32);
+        check_encodes_like_display_and_decodes(&(u32::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(u32::max_value()));
 
-        check_encodes_like_display(&0u64);
-        check_encodes_like_display(&42u64);
-        check_encodes_like_display(&(u64::max_value() - 1));
-        check_encodes_like_display(&(u64::max_value()));
+        check_encodes_like_display_and_decodes(&0u64);
+        check_encodes_like_display_and_decodes(&42u64);
+        check_encodes_like_display_and_decodes(&(u64::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(u64::max_value()));
 
-        check_encodes_like_display(&0u128);
-        check_encodes_like_display(&42u128);
-        check_encodes_like_display(&(u128::max_value() - 1));
-        check_encodes_like_display(&(u128::max_value()));
+        check_encodes_like_display_and_decodes(&0u128);
+        check_encodes_like_display_and_decodes(&42u128);
+        check_encodes_like_display_and_decodes(&(u128::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(u128::max_value()));
 
-        check_encodes_like_display(&0usize);
-        check_encodes_like_display(&42usize);
-        check_encodes_like_display(&(usize::max_value() - 1));
-        check_encodes_like_display(&(usize::max_value()));
+        check_encodes_like_display_and_decodes(&0usize);
+        check_encodes_like_display_and_decodes(&42usize);
+        check_encodes_like_display_and_decodes(&(usize::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(usize::max_value()));
     }
 
     #[test]
     fn test_encode_signed() {
-        check_encodes_like_display(&0i8);
-        check_encodes_like_display(&-1i8);
-        check_encodes_like_display(&42i8);
-        check_encodes_like_display(&-42i8);
-        check_encodes_like_display(&(i8::min_value()));
-        check_encodes_like_display(&(i8::min_value() + 1));
-        check_encodes_like_display(&(i8::max_value() - 1));
-        check_encodes_like_display(&(i8::max_value()));
+        check_encodes_like_display_and_decodes(&0i8);
+        check_encodes_like_display_and_decodes(&-1i8);
+        check_encodes_like_display_and_decodes(&42i8);
+        check_encodes_like_display_and_decodes(&-42i8);
+        check_encodes_like_display_and_decodes(&(i8::min_value()));
+        check_encodes_like_display_and_decodes(&(i8::min_value() + 1));
+        check_encodes_like_display_and_decodes(&(i8::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(i8::max_value()));
 
-        check_encodes_like_display(&0i16);
-        check_encodes_like_display(&-1i16);
-        check_encodes_like_display(&42i16);
-        check_encodes_like_display(&-42i16);
-        check_encodes_like_display(&(i16::min_value()));
-        check_encodes_like_display(&(i16::min_value() + 1));
-        check_encodes_like_display(&(i16::max_value() - 1));
-        check_encodes_like_display(&(i16::max_value()));
+        check_encodes_like_display_and_decodes(&0i16);
+        check_encodes_like_display_and_decodes(&-1i16);
+        check_encodes_like_display_and_decodes(&42i16);
+        check_encodes_like_display_and_decodes(&-42i16);
+        check_encodes_like_display_and_decodes(&(i16::min_value()));
+        check_encodes_like_display_and_decodes(&(i16::min_value() + 1));
+        check_encodes_like_display_and_decodes(&(i16::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(i16::max_value()));
 
-        check_encodes_like_display(&0i32);
-        check_encodes_like_display(&-1i32);
-        check_encodes_like_display(&42i32);
-        check_encodes_like_display(&-42i32);
-        check_encodes_like_display(&(i32::min_value()));
-        check_encodes_like_display(&(i32::min_value() + 1));
-        check_encodes_like_display(&(i32::max_value() - 1));
-        check_encodes_like_display(&(i32::max_value()));
+        check_encodes_like_display_and_decodes(&0i32);
+        check_encodes_like_display_and_decodes(&-1i32);
+        check_encodes_like_display_and_decodes(&42i32);
+        check_encodes_like_display_and_decodes(&-42i32);
+        check_encodes_like_display_and_decodes(&(i32::min_value()));
+        check_encodes_like_display_and_decodes(&(i32::min_value() + 1));
+        check_encodes_like_display_and_decodes(&(i32::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(i32::max_value()));
 
-        check_encodes_like_display(&0i64);
-        check_encodes_like_display(&-1i64);
-        check_encodes_like_display(&42i64);
-        check_encodes_like_display(&-42i64);
-        check_encodes_like_display(&(i64::min_value()));
-        check_encodes_like_display(&(i64::min_value() + 1));
-        check_encodes_like_display(&(i64::max_value() - 1));
-        check_encodes_like_display(&(i64::max_value()));
+        check_encodes_like_display_and_decodes(&0i64);
+        check_encodes_like_display_and_decodes(&-1i64);
+        check_encodes_like_display_and_decodes(&42i64);
+        check_encodes_like_display_and_decodes(&-42i64);
+        check_encodes_like_display_and_decodes(&(i64::min_value()));
+        check_encodes_like_display_and_decodes(&(i64::min_value() + 1));
+        check_encodes_like_display_and_decodes(&(i64::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(i64::max_value()));
 
-        check_encodes_like_display(&0i128);
-        check_encodes_like_display(&-1i128);
-        check_encodes_like_display(&42i128);
-        check_encodes_like_display(&-42i128);
-        check_encodes_like_display(&(i128::min_value()));
-        check_encodes_like_display(&(i128::min_value() + 1));
-        check_encodes_like_display(&(i128::max_value() - 1));
-        check_encodes_like_display(&(i128::max_value()));
+        check_encodes_like_display_and_decodes(&0i128);
+        check_encodes_like_display_and_decodes(&-1i128);
+        check_encodes_like_display_and_decodes(&42i128);
+        check_encodes_like_display_and_decodes(&-42i128);
+        check_encodes_like_display_and_decodes(&(i128::min_value()));
+        check_encodes_like_display_and_decodes(&(i128::min_value() + 1));
+        check_encodes_like_display_and_decodes(&(i128::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(i128::max_value()));
 
-        check_encodes_like_display(&0isize);
-        check_encodes_like_display(&-1isize);
-        check_encodes_like_display(&42isize);
-        check_encodes_like_display(&-42isize);
-        check_encodes_like_display(&(isize::min_value()));
-        check_encodes_like_display(&(isize::min_value() + 1));
-        check_encodes_like_display(&(isize::max_value() - 1));
-        check_encodes_like_display(&(isize::max_value()));
+        check_encodes_like_display_and_decodes(&0isize);
+        check_encodes_like_display_and_decodes(&-1isize);
+        check_encodes_like_display_and_decodes(&42isize);
+        check_encodes_like_display_and_decodes(&-42isize);
+        check_encodes_like_display_and_decodes(&(isize::min_value()));
+        check_encodes_like_display_and_decodes(&(isize::min_value() + 1));
+        check_encodes_like_display_and_decodes(&(isize::max_value() - 1));
+        check_encodes_like_display_and_decodes(&(isize::max_value()));
     }
 
     #[test]
     fn test_encode_module_version() {
-        check_encodes_like_display(&ModuleVersion { major: 1, minor: 0 });
-        check_encodes_like_display(&ModuleVersion { major: 23, minor: 42 });
-        check_encodes_like_display(&ModuleVersion { major: 1, minor: u16::max_value() });
-        check_encodes_like_display(&ModuleVersion { major: u16::max_value() - 1, minor: 2 });
+        check_encodes_like_display_and_decodes(&ModuleVersion { major: 1, minor: 0 });
+        check_encodes_like_display_and_decodes(&ModuleVersion { major: 23, minor: 42 });
+        check_encodes_like_display_and_decodes(&ModuleVersion { major: 1, minor: u16::max_value() });
+        check_encodes_like_display_and_decodes(&ModuleVersion { major: u16::max_value() - 1, minor: 2 });
     }
 
 }

--- a/src/common/core/mod.rs
+++ b/src/common/core/mod.rs
@@ -16,6 +16,8 @@
 *
 ******************************************************************************/
 
+mod decode_argument;
+pub use self::decode_argument::*;
 mod encode_argument;
 pub use self::encode_argument::*;
 mod module_version;

--- a/src/common/core/module_version.rs
+++ b/src/common/core/module_version.rs
@@ -16,7 +16,7 @@
 *
 ******************************************************************************/
 
-use common::core::EncodeArgument;
+use common::core::{DecodeArgument, EncodeArgument};
 
 use std::fmt;
 
@@ -34,7 +34,7 @@ impl fmt::Display for ModuleVersion {
     }
 }
 
-//NOTE: Tests for this trait impl are in 
+//NOTE: Tests for this trait impl are in src/common/core/encode_argument.rs.
 impl EncodeArgument for ModuleVersion {
     fn get_size(&self) -> usize {
         self.major.get_size() + 1 + self.minor.get_size()
@@ -45,5 +45,21 @@ impl EncodeArgument for ModuleVersion {
         self.major.encode(&mut buf[0 .. major_size]);
         buf[major_size] = b'.';
         self.minor.encode(&mut buf[major_size+1 .. ]);
+    }
+}
+
+//NOTE: Tests for this trait impl are in src/common/core/{decode,encode}_argument.rs.
+impl DecodeArgument for ModuleVersion {
+    fn decode(arg: &[u8]) -> Option<ModuleVersion> {
+        let mut iter = arg.split(|&ch| ch == b'.');
+        //since we expect the format "X.Y", there must be exactly two subslices
+        //in this iterator
+        let major = u16::decode(iter.next()?)?;
+        let minor = u16::decode(iter.next()?)?;
+        if iter.next().is_some() {
+            None
+        } else {
+            Some(ModuleVersion { major: major, minor: minor })
+        }
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,20 +1,20 @@
-/*******************************************************************************
+/******************************************************************************
 *
-* Copyright 2018 Stefan Majewsky <majewsky@gmx.net>
+*  Copyright 2018 Stefan Majewsky <majewsky@gmx.net>
 *
-* This program is free software: you can redistribute it and/or modify it under
-* the terms of the GNU General Public License as published by the Free Software
-* Foundation, either version 3 of the License, or (at your option) any later
-* version.
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
 *
-* This program is distributed in the hope that it will be useful, but WITHOUT ANY
-* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-* A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*      http://www.apache.org/licenses/LICENSE-2.0
 *
-* You should have received a copy of the GNU General Public License along with
-* this program. If not, see <http://www.gnu.org/licenses/>.
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
 *
-*******************************************************************************/
+******************************************************************************/
 
 ///Common types and definitions for the [vt6/core module](https://vt6.io/std/core/).
 pub mod core;

--- a/src/server/core/handler.rs
+++ b/src/server/core/handler.rs
@@ -61,12 +61,12 @@ impl<H> Handler<H> {
             return None;
         }
         for arg in args_iter.clone() {
-            let major_version = str::from_utf8(arg).ok()?.parse::<u16>().ok()?;
+            let major_version = u16::decode(arg)?;
             if major_version == 0 {
                 return None;
             }
         }
-        let major_versions_iter = args_iter.map(|arg| str::from_utf8(arg).unwrap().parse::<u16>().unwrap());
+        let major_versions_iter = args_iter.map(|arg| u16::decode(arg).unwrap());
         let check_want_result = self.check_want(module_name, major_versions_iter, conn);
 
         match check_want_result {

--- a/src/server/core/tests.rs
+++ b/src/server/core/tests.rs
@@ -1,20 +1,20 @@
-/*******************************************************************************
+/******************************************************************************
 *
-* Copyright 2018 Stefan Majewsky <majewsky@gmx.net>
+*  Copyright 2018 Stefan Majewsky <majewsky@gmx.net>
 *
-* This program is free software: you can redistribute it and/or modify it under
-* the terms of the GNU General Public License as published by the Free Software
-* Foundation, either version 3 of the License, or (at your option) any later
-* version.
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
 *
-* This program is distributed in the hope that it will be useful, but WITHOUT ANY
-* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-* A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*      http://www.apache.org/licenses/LICENSE-2.0
 *
-* You should have received a copy of the GNU General Public License along with
-* this program. If not, see <http://www.gnu.org/licenses/>.
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
 *
-*******************************************************************************/
+******************************************************************************/
 
 use std;
 


### PR DESCRIPTION
To complement EncodeArgument.

For now, only the trait implementation for integers is used. I used `str::parse::<u16>` instead of `u16::decode` before, (see diff in `vt6::server::core::Handler` at the end of the diff display), but that is actually wrong since `parse` accepts inputs that are not legal by the vt6/core1.0 spec (in partiular, non-zero values with leading zeroes like "0012").